### PR TITLE
update query documentation to clarify that query bindings and arguments can also be specified as symbols

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,8 +7,10 @@ Cerner Corporation
 Others
 
 - Mathias De Wachter [@lambda-ai]
+- Jose Gomez [@k13gomez]
 
 [@rbrush]: https://github.com/rbrush
 [@mrrodriguez]: https://github.com/mrrodriguez
 [@WilliamParker]: https://github.com/WilliamParker
 [@lambda-ai]: https://github.com/lambda-ai
+[@k13gomez]: https://github.com/k13gomez

--- a/_docs/queries.md
+++ b/_docs/queries.md
@@ -12,7 +12,7 @@ Queries are typically defined with **defquery**, which has the following structu
 
 A query has two major pieces:
 
-* A parameter definition, which allow callers to control the scope of the query when it is called.
+* A parameter definition, which allow callers to control the scope of the query when it is called. Parameters can be specified as symbols or keywords.
 * One or more conditions, which define the facts matching the query. These conditions are the same structure as a rule left-hand side.
 
 A sample query looks like this:
@@ -20,14 +20,14 @@ A sample query looks like this:
 {% highlight clojure %}
 (defquery get-promotions
   "Query to find promotions for the purchase."
-  [:?type]
+  [?type] ;;; can also be specified using a keyword as :?type, but symbols are more idiomatic to specify bindings.
   [?promotion <- Promotion (= ?type type)])
 {% endhighlight %}
 
 A caller may then execute that query with arguments. So if we only wanted to find lunch promotions, we might perform the query like this:
 
 {% highlight clojure %}
-(query session get-promotions :?type :lunch)
+(query session get-promotions :?type :lunch) ;;; the :?type value can also be specified as a symbol '?type, but keywords are more idiomatic to specify arguments.
 {% endhighlight %}
 
 Some queries may have no parameters. Queries return a sequence of results, with each result being a map of the a bound variable to its value. So the above query may return a sequence that looks like this:


### PR DESCRIPTION
This follows up on: https://github.com/cerner/clara-rules/pull/463