### PR TITLE
Add installation instructions for tools.deps

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,9 +8,11 @@ Others
 
 - Mathias De Wachter [@lambda-ai]
 - Jose Gomez [@k13gomez]
+- Sebastian Crane [@seabass-labrax]
 
 [@rbrush]: https://github.com/rbrush
 [@mrrodriguez]: https://github.com/mrrodriguez
 [@WilliamParker]: https://github.com/WilliamParker
 [@lambda-ai]: https://github.com/lambda-ai
 [@k13gomez]: https://github.com/k13gomez
+[@seabass-labrax]: https://github.com/seabass-labrax

--- a/_docs/firststeps.md
+++ b/_docs/firststeps.md
@@ -12,6 +12,12 @@ Let's get started! The first thing you'll need to do is bring Clara into your pr
 [com.cerner/clara-rules "{{site.clara_version}}"]
 {% endhighlight %}
 
+or, for tools.deps, in `deps.edn`:
+
+{% highlight clojure %}
+com.cerner/clara-rules {:mvn/version "{{site.clara_version}}"}
+{% endhighlight %}
+
 or to your Maven POM:
 
 {% highlight xml %}


### PR DESCRIPTION
This pull request adds to the 'First Steps' page instructions for using Clara with the 'tools.deps' dependency manager, which is included with recent versions of Clojure.